### PR TITLE
PCAI-86: Доработка сервиса: при авторизации пользователя получать информацию профиля и сохранять в БД и в кеш

### DIFF
--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/controller/AuthController.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/controller/AuthController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.dto.AccessTokenResponse;
 import ru.perevalov.gamerecommenderai.dto.OpenIdResponse;
 import ru.perevalov.gamerecommenderai.dto.PreAuthResponse;
@@ -77,12 +78,19 @@ public class AuthController {
      * Ловим callback от провайдера аутентификации, верифицируем ответ от Steam.
      * Возвращает новые Refresh и Access токены в случае привязки пользователя по Steam Id
      */
+//    @GetMapping("/steam/return")
+//    public ResponseEntity<AccessTokenResponse> handleSteamCallback(OpenIdResponse openIdResponse,
+//                                                                   HttpServletRequest request,
+//                                                                   HttpServletResponse response) {
+//        AccessTokenResponse handledResponse = steamOpenIdResponseHandler.handle(openIdResponse, request, response);
+//        return ResponseEntity.ok(handledResponse);
+//    }
     @GetMapping("/steam/return")
-    public ResponseEntity<AccessTokenResponse> handleSteamCallback(OpenIdResponse openIdResponse,
-                                                                   HttpServletRequest request,
-                                                                   HttpServletResponse response) {
-        AccessTokenResponse handledResponse = steamOpenIdResponseHandler.handle(openIdResponse, request, response);
-        return ResponseEntity.ok(handledResponse);
+    public Mono<ResponseEntity<AccessTokenResponse>> handleSteamCallback(OpenIdResponse openIdResponse,
+                                                                         HttpServletRequest request,
+                                                                         HttpServletResponse response) {
+        return steamOpenIdResponseHandler.handle(openIdResponse, request, response)
+                .map(ResponseEntity::ok);
     }
 
 

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/mapper/SteamProfileMapper.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/mapper/SteamProfileMapper.java
@@ -1,0 +1,40 @@
+package ru.perevalov.gamerecommenderai.mapper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import ru.perevalov.gamerecommenderai.dto.steam.SteamPlayerResponse;
+import ru.perevalov.gamerecommenderai.entity.SteamProfile;
+
+import java.util.List;
+
+@Component
+@Slf4j
+public class SteamProfileMapper {
+
+    public static Mono<SteamProfile> map(SteamPlayerResponse response) {
+
+        if (response == null || response.getResponse() == null ||
+                response.getResponse().getPlayers() == null ||
+                response.getResponse().getPlayers().isEmpty()) {
+            log.warn("The Steam profile does not contain any players — it is possible that the SteamID is incorrect");
+            return Mono.empty();
+        }
+
+        return Mono.justOrEmpty(response)
+                .map(SteamPlayerResponse::getResponse)
+                .map(SteamPlayerResponse.Response::getPlayers)
+                .filter(players -> !players.isEmpty())
+                .map(List::getFirst)
+                .map(player -> {
+                    SteamProfile profile = new SteamProfile();
+                    profile.setSteamId(player.getSteamId());
+                    profile.setPersonaName(player.getPersonaName());
+                    profile.setAvatarFull(player.getAvatarFull());
+
+                    log.info("Successfully swapped the profile for {}", player.getSteamId());
+
+                    return profile;
+                });
+    }
+}

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/steam/SteamOpenIdResponseHandler.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/steam/SteamOpenIdResponseHandler.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.dto.AccessTokenResponse;
 import ru.perevalov.gamerecommenderai.dto.OpenIdResponse;
 import ru.perevalov.gamerecommenderai.entity.User;
@@ -14,6 +15,7 @@ import ru.perevalov.gamerecommenderai.exception.ErrorType;
 import ru.perevalov.gamerecommenderai.exception.GameRecommenderException;
 import ru.perevalov.gamerecommenderai.security.CookieService;
 import ru.perevalov.gamerecommenderai.security.TokenService;
+import ru.perevalov.gamerecommenderai.service.SteamUserDataUpdater;
 import ru.perevalov.gamerecommenderai.service.UserService;
 
 /**
@@ -27,6 +29,7 @@ public class SteamOpenIdResponseHandler {
     private final UserService userService;
     private final TokenService tokenService;
     private final CookieService cookieService;
+    private final SteamUserDataUpdater steamUserDataUpdater;
 
     /**
      * * Handler охватывает следующие шаги:
@@ -39,30 +42,65 @@ public class SteamOpenIdResponseHandler {
      * @param request        - содержат Refresh токен, в которые вшивается Steam id
      * @return
      */
-    public AccessTokenResponse handle(OpenIdResponse openIdResponse,
-                                      HttpServletRequest request,
-                                      HttpServletResponse response) {
-        steamOpenIdService.verifyResponse(openIdResponse);
-        Long steamId = steamOpenIdService.extractSteamIdFromClaimedId(openIdResponse.getClaimedId());
-        log.info("Received OpenID callback, steamId={}", steamId);
+//    public AccessTokenResponse handle(OpenIdResponse openIdResponse,
+//                                      HttpServletRequest request,
+//                                      HttpServletResponse response) {
+//        steamOpenIdService.verifyResponse(openIdResponse);
+//        Long steamId = steamOpenIdService.extractSteamIdFromClaimedId(openIdResponse.getClaimedId());
+//        log.info("Received OpenID callback, steamId={}", steamId);
+//
+//        User user = userService.createIfNotExists(steamId);
+//
+//        Cookie[] cookies = request.getCookies();
+//        String refreshTokenFromCookies = cookieService.extractRefreshTokenFromCookies(cookies);
+//
+//        if (refreshTokenFromCookies != null && !refreshTokenFromCookies.isBlank()) {
+//            log.info("Found refresh token from cookie. Link steamId {} with refresh token", user.getSteamId());
+//            return tokenService.linkSteamIdToToken(refreshTokenFromCookies, user.getSteamId(), response);
+//        } else {
+//            String refreshTokenFromHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+//
+//            if (refreshTokenFromHeader == null || refreshTokenFromHeader.isBlank()) {
+//                log.error("Missing authorization header when trying to inject steam id in to the JWT token " +
+//                        "for user with id {}", user.getId());
+//                throw new GameRecommenderException(ErrorType.MISSING_AUTHORIZATION_HEADER);
+//            }
+//            return tokenService.linkSteamIdToToken(refreshTokenFromHeader, user.getSteamId(), response);
+//        }
+//    }
+    public Mono<AccessTokenResponse> handle(OpenIdResponse openIdResponse,
+                                                    HttpServletRequest request,
+                                                    HttpServletResponse response) {
+        return steamOpenIdService.verifyResponse(openIdResponse)
+                .then(steamOpenIdService.extractSteamIdFromClaimedId(openIdResponse.getClaimedId()))
+                .flatMap(steamId -> {
+                    log.info("Received OpenID callback, steamId={}", steamId);
 
-        User user = userService.createIfNotExists(steamId);
+                    return userService.createIfNotExists(steamId)
+                            .flatMap(user ->
+                                    steamUserDataUpdater.updateUserData(user.getSteamId())
+                                            .then(linkTokens(user, request, response))
+                            );
+                });
+    }
 
-        Cookie[] cookies = request.getCookies();
-        String refreshTokenFromCookies = cookieService.extractRefreshTokenFromCookies(cookies);
+    private Mono<AccessTokenResponse> linkTokens(User user,
+                                                 HttpServletRequest request,
+                                                 HttpServletResponse response) {
+        String refreshTokenFromCookies = cookieService.extractRefreshTokenFromCookies(request.getCookies());
 
         if (refreshTokenFromCookies != null && !refreshTokenFromCookies.isBlank()) {
             log.info("Found refresh token from cookie. Link steamId {} with refresh token", user.getSteamId());
             return tokenService.linkSteamIdToToken(refreshTokenFromCookies, user.getSteamId(), response);
-        } else {
-            String refreshTokenFromHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-            if (refreshTokenFromHeader == null || refreshTokenFromHeader.isBlank()) {
-                log.error("Missing authorization header when trying to inject steam id in to the JWT token " +
-                        "for user with id {}", user.getId());
-                throw new GameRecommenderException(ErrorType.MISSING_AUTHORIZATION_HEADER);
-            }
-            return tokenService.linkSteamIdToToken(refreshTokenFromHeader, user.getSteamId(), response);
         }
+
+        String refreshTokenFromHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (refreshTokenFromHeader == null || refreshTokenFromHeader.isBlank()) {
+            log.error("Missing authorization header when trying to inject steam id in to the JWT token " +
+                    "for user with id {}", user.getId());
+            return Mono.error(new GameRecommenderException(ErrorType.MISSING_AUTHORIZATION_HEADER));
+        }
+
+        return tokenService.linkSteamIdToToken(refreshTokenFromHeader, user.getSteamId(), response);
     }
 }

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/SteamService.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/SteamService.java
@@ -1,7 +1,9 @@
 package ru.perevalov.gamerecommenderai.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.client.SteamUserClient;
 import ru.perevalov.gamerecommenderai.dto.steam.SteamOwnedGamesResponse;
 import ru.perevalov.gamerecommenderai.dto.steam.SteamPlayerResponse;
@@ -12,7 +14,7 @@ import ru.perevalov.gamerecommenderai.dto.steam.SteamPlayerResponse;
  * Использует {@link SteamUserClient} для обращения к Steam Web API.
  * Предоставляет методы:
  * <ul>
- *     <li>getPlayerSummaries — получить информацию о пользователях по Steam ID</li>
+ *     <li>getPlayerSummariesReactive — получить информацию о пользователе по Steam ID</li>
  *     <li>getOwnedGames — получить список игр пользователя с деталями</li>
  * </ul>
  * <p>
@@ -20,12 +22,25 @@ import ru.perevalov.gamerecommenderai.dto.steam.SteamPlayerResponse;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SteamService {
 
     private final SteamUserClient steamUserClient;
 
-    public SteamPlayerResponse getPlayerSummaries(String steamId) {
-        return steamUserClient.fetchPlayerSummaries(steamId);
+//    public SteamPlayerResponse getPlayerSummaries(String steamId) {
+//        return steamUserClient.fetchPlayerSummaries(steamId);
+//    }
+
+    public Mono<SteamPlayerResponse> getPlayerSummaries(Long steamId) {
+        log.debug("Reactive service: request data for {}", steamId);
+
+        return steamUserClient.fetchPlayerSummaries(String.valueOf(steamId))
+                .doOnNext(response ->
+                        log.debug("The service received data for {}", steamId)
+                )
+                .doOnError(error ->
+                        log.error("Error in the service for {}: {}", steamId, error.getMessage())
+                );
     }
 
     public SteamOwnedGamesResponse getOwnedGames(String steamId,

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/SteamUserDataUpdater.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/SteamUserDataUpdater.java
@@ -1,0 +1,57 @@
+package ru.perevalov.gamerecommenderai.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import ru.perevalov.gamerecommenderai.mapper.SteamProfileMapper;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SteamUserDataUpdater {
+    private final SteamService steamService;
+
+    public Mono<Void> updateUserData(Long steamId) {
+        log.info("🚀 Запуск обновления данных для {}", steamId);
+
+        return updateSteamProfile(steamId)
+                .then(updateUserGameStats(steamId))
+                .doOnSuccess(v ->
+                        log.info("All data has been updated for {}", steamId)
+                )
+                .doOnError(e ->
+                        log.error("Error update for {}: {}", steamId, e.getMessage()
+                        )
+                );
+    }
+
+    public Mono<Void> updateSteamProfile(Long steamId) {
+        log.debug("Updating SteamProfile, steamId: {}", steamId);
+
+        return steamService.getPlayerSummaries(steamId)
+                .flatMap(SteamProfileMapper::map)
+                .flatMap(profile -> {
+
+                    //сохранение в базу
+
+                    log.info("SteamProfile saved in the database, steamId: {}",
+                            steamId);
+                    return Mono.empty();
+                })
+                .switchIfEmpty(Mono.defer(() -> {
+                    log.warn("Error mapping SteamProfile, steamId: {}", steamId);
+                    return Mono.empty();
+                }))
+                .doOnError(error ->
+                        log.error("Error update SteamProfile, steamId: {} : {}", steamId, error.getMessage())
+                )
+                .then();
+    }
+
+    public Mono<Void> updateUserGameStats(Long steamId) {
+        //логика обновления статистики по играм
+        return Mono.empty();
+    }
+
+}

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/UserService.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/UserService.java
@@ -3,11 +3,11 @@ package ru.perevalov.gamerecommenderai.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.entity.User;
 import ru.perevalov.gamerecommenderai.exception.ErrorType;
 import ru.perevalov.gamerecommenderai.exception.GameRecommenderException;
 import ru.perevalov.gamerecommenderai.repository.UserRepository;
-import ru.perevalov.gamerecommenderai.security.model.UserRole;
 
 @Slf4j
 @Service
@@ -25,13 +25,18 @@ public class UserService {
         return user;
     }
 
-    public User createIfNotExists(Long steamId) {
-        return userRepository.findBySteamId(steamId)
-                .orElseGet(() -> {
-                            User saved = userRepository.save(new User(steamId, UserRole.USER));
-                            log.info("Created new user with steamId={} (userId={}).", saved.getSteamId(), saved.getId());
-                            return saved;
-                        }
-                );
+//        public User createIfNotExists(Long steamId) {
+//        return userRepository.findBySteamId(steamId)
+//                .orElseGet(() -> {
+//                            User saved = userRepository.save(new User(steamId, UserRole.USER));
+//                            log.info("Created new user with steamId={} (userId={}).", saved.getSteamId(), saved.getId());
+//                            return saved;
+//                        }
+//                );
+//    }
+    public Mono<User> createIfNotExists(Long steamId) {
+        //todo: реализовать логику поиска и создания пользователя
+        User dummy = new User();
+        return Mono.just(dummy);
     }
 }


### PR DESCRIPTION
Частично реализовано сохранение данных SteamProfile из Steam API после авторизации
Таска решалась исходя из entity класса SteamProfile с полями(сейчас они не такие):
private String steamId;
private String personaName;
private String avatarFull;
private UUID userId;
В дальнейшем так же необходимо исправить entity класс UserGameStats, что бы он имел поля как у вложенного класса Game из SteamOwnedGamesResponse.
Все тесты разумеется провальные из-за обширного реактивного рефакторинга.