### PR TITLE
PCAI-80: Миграция контроллеров на webFlux + попутные фиксы:

### DIFF
--- a/services/backend/pom.xml
+++ b/services/backend/pom.xml
@@ -55,10 +55,10 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.boot</groupId>-->
+<!--            <artifactId>spring-boot-starter-data-jpa</artifactId>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -149,10 +149,16 @@
         </dependency>
 
         <!-- Swagger/OpenAPI -->
+<!--        <dependency>-->
+<!--            <groupId>org.springdoc</groupId>-->
+<!--            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>-->
+<!--            <version>${springdoc.version}</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webflux-api</artifactId>
             <version>${springdoc.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Test -->

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/GameRecommenderAiApplication.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/GameRecommenderAiApplication.java
@@ -13,12 +13,7 @@ import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-// TODO: Удалить exclude после завершения задачи PCAI-78
-@SpringBootApplication(exclude = {
-        R2dbcAutoConfiguration.class,
-        R2dbcDataAutoConfiguration.class,
-        R2dbcRepositoriesAutoConfiguration.class
-})
+@SpringBootApplication
 @EnableConfigurationProperties
 @EnableCaching
 @EnableAspectJAutoProxy

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/OpenApiConfig.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/OpenApiConfig.java
@@ -1,54 +1,59 @@
 package ru.perevalov.gamerecommenderai.config;
 
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Contact;
-import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.info.License;
-import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
+//import io.swagger.v3.oas.models.Components;
+//import io.swagger.v3.oas.models.OpenAPI;
+//import io.swagger.v3.oas.models.info.Contact;
+//import io.swagger.v3.oas.models.info.Info;
+//import io.swagger.v3.oas.models.info.License;
+//import io.swagger.v3.oas.models.servers.Server;
+//import io.swagger.v3.oas.models.security.SecurityRequirement;
+//import io.swagger.v3.oas.models.security.SecurityScheme;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Зависимость Open API была заменена на рекативную для работы с webFlux. Старая конфигурация не работает и была закомменчена,
+ * Новую не успеваю сделать, а коммит нужно сделать быстрее, т.к. несколько других задач зависят от моих изменений
+ * TODO: Настроить реактивный OPEN API!!!
+ */
 @Configuration
 public class OpenApiConfig {
 
     public static final String BEARER_SCHEME = "bearerAuth";
 
-    @Bean
-    public OpenAPI customOpenAPI() {
-        return new OpenAPI()
-                .info(new Info()
-                        .title("Game Recommender AI API")
-                        .description("""
-                                API для рекомендации игр с использованием DeepSeek AI.
-                                Для тестирования защищённых эндпоинтов нужно получить токен
-                                через `/api/v1/auth/preAuthorize`,
-                                нажать **Authorize** в Swagger UI и вставить свой JWT — после этого токен будет
-                                автоматически подставляться в запросы.
-                                """)
-                        .version("1.0.0")
-                        .contact(new Contact()
-                                .name("Game Recommender Team")
-                                .email("support@gamerecommender.com"))
-                        .license(new License()
-                                .name("MIT License")
-                                .url("https://opensource.org/licenses/MIT")))
-                .servers(List.of(
-                        new Server()
-                                .url("http://localhost:8080")
-                                .description("Local Development Server"),
-                        new Server()
-                                .url("https://api.gamerecommender.com")
-                                .description("Production Server")
-                ))
-                .components(new Components()
-                        .addSecuritySchemes(BEARER_SCHEME, new SecurityScheme()
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")))
-                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME));
-    }
+//    @Bean
+//    public OpenAPI customOpenAPI() {
+//        return new OpenAPI()
+//                .info(new Info()
+//                        .title("Game Recommender AI API")
+//                        .description("""
+//                                API для рекомендации игр с использованием DeepSeek AI.
+//                                Для тестирования защищённых эндпоинтов нужно получить токен
+//                                через `/api/v1/auth/preAuthorize`,
+//                                нажать **Authorize** в Swagger UI и вставить свой JWT — после этого токен будет
+//                                автоматически подставляться в запросы.
+//                                """)
+//                        .version("1.0.0")
+//                        .contact(new Contact()
+//                                .name("Game Recommender Team")
+//                                .email("support@gamerecommender.com"))
+//                        .license(new License()
+//                                .name("MIT License")
+//                                .url("https://opensource.org/licenses/MIT")))
+//                .servers(List.of(
+//                        new Server()
+//                                .url("http://localhost:8080")
+//                                .description("Local Development Server"),
+//                        new Server()
+//                                .url("https://api.gamerecommender.com")
+//                                .description("Production Server")
+//                ))
+//                .components(new Components()
+//                        .addSecuritySchemes(BEARER_SCHEME, new SecurityScheme()
+//                                .type(SecurityScheme.Type.HTTP)
+//                                .scheme("bearer")
+//                                .bearerFormat("JWT")))
+//                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME));
+//    }
 }

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/SecurityConfig.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/SecurityConfig.java
@@ -4,44 +4,66 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.server.SecurityWebFilterChain;
 import ru.perevalov.gamerecommenderai.filter.JwtRequestFilter;
 import ru.perevalov.gamerecommenderai.security.model.UserRole;
 
 @Configuration
-@EnableWebSecurity
+//@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtRequestFilter jwtRequestFilter;
+    //private final JwtRequestFilter jwtRequestFilter;
 
+    //TODO: Старая цепочка фильтров закомментированна, т.к. работает на сервлетах (Tomcat), что не позволяет использовать
+    // реактивные контроллеры. В pom.xml пока была оставлена зависимость "spring-boot-starter-web", т.к. без нее
+    // приложение падает в попытке сконфигурировать бины спринг секьюрити, которые зависят от неё. А чтобы все поднималось
+    // все-таки на реактивном netty, в проперти добавлена "spring.main.web-application-type=reactive"
+    // ----------
+    // Итак, в итоге на данный момент имеем:
+    // + В помнике есть зависимости и для tomcat, и для реактивного netty
+    // + Внизу бин конфигурации минимальной реактивной секьюрити filter cahin, пропускающий все
+    // + Старый filter chain был закомментирован во избежание конфликта при старте
+    // + Весь функционал, связанный со старым секьюрити и все нереактивные контроллеры >>>> НЕ РАБОТАЮТ <<<<
+    // (если не будет возвращено старое состояние)
+    // ----------
+    // Чтобы вернуть старое состояние, при котором работают нереактивные эндпоинты и вся старая секьюрити система,
+    // необходимо разкомментировать в этом классе все, что сейчас закомменчено, а бин "springSecurityFilterChain" наоборот
+    // закомментировать или удалить. Так-же в пропертях убрать, закомментить или переключить на "servlet" строку
+    // "spring.main.web-application-type=reactive"
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .cors(Customizer.withDefaults())
-                .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/v1/auth/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/v3/api-docs/**",
-                                "/api-docs/**",
-                                "/actuator/health",
-                                "/actuator/prometheus"
-                        ).permitAll()
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/api/v1/private/**").hasAuthority(UserRole.USER.getAuthority())
-                        .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
-
-        return http.build();
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        return http.csrf(csrf -> csrf.disable())
+                .authorizeExchange(exchanges -> exchanges.anyExchange().permitAll()).build();
     }
+
+//    @Bean
+//    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+//        http
+//                .csrf(AbstractHttpConfigurer::disable)
+//                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers(
+//                                "/api/v1/auth/**",
+//                                "/swagger-ui/**",
+//                                "/swagger-ui.html",
+//                                "/v3/api-docs/**",
+//                                "/api-docs/**",
+//                                "/actuator/health",
+//                                "/actuator/prometheus"
+//                        ).permitAll()
+//                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+//                        .requestMatchers("/api/v1/private/**").hasAuthority(UserRole.USER.getAuthority())
+//                        .anyRequest().authenticated()
+//                )
+//                .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+//
+//        return http.build();
+//    }
 }

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/controller/AuthController.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/controller/AuthController.java
@@ -14,7 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.dto.AccessTokenResponse;
 import ru.perevalov.gamerecommenderai.dto.OpenIdResponse;
 import ru.perevalov.gamerecommenderai.dto.PreAuthResponse;
@@ -26,6 +28,11 @@ import ru.perevalov.gamerecommenderai.security.steam.SteamOpenIdResponseHandler;
 
 import java.net.URI;
 
+/**
+ * Старые MVC контроллеры были переименованы (добавлен суффикс Old в конец названия метода). Они все еще обращаются к старой
+ * логике, но принять запросы через netty не могут. Новые еактивные методы работают, но обращаются к методам-заглушкам в
+ * сервисных классах
+ */
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -39,27 +46,48 @@ public class AuthController {
     private final SteamOpenIdResponseHandler steamOpenIdResponseHandler;
     private final TokenService tokenService;
 
-    @PostMapping("/preAuthorize")
-    public ResponseEntity<PreAuthResponse> preAuthorize(HttpServletResponse response) {
+    @Deprecated(forRemoval = true)
+    @PostMapping("/preAuthorizeOld")
+    public ResponseEntity<PreAuthResponse> preAuthorizeOld(HttpServletResponse response) {
         PreAuthResponse resp = tokenService.preAuthorize(response);
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + resp.getAccessToken())
                 .body(resp);
     }
 
-    @PostMapping("/refresh")
-    public ResponseEntity<AccessTokenResponse> refreshAccessToken(HttpServletRequest request,
-                                                                  HttpServletResponse response) {
+    /** Старый preAuthorize метод был переименован в preAuthorizeOld. Новый preAuthorize работает реактивно. На данный
+     * момент обращается к методу-заглушке preAuthorizeReactively() в TokenService
+     */
+    @PostMapping("/preAuthorize")
+    public Mono<ResponseEntity<PreAuthResponse>> preAuthorize(ServerWebExchange exchange) {
+        return tokenService
+                .preAuthorizeReactively(exchange) //TODO: Заменить вызов метода заглушки на готовый реактивный метод
+                .map(resp -> ResponseEntity.ok()
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + resp.getAccessToken())
+                        .body(resp));
+    }
+
+    @Deprecated(forRemoval = true)
+    @PostMapping("/refreshOld")
+    public ResponseEntity<AccessTokenResponse> refreshAccessTokenOld(HttpServletRequest request,
+                                                                     HttpServletResponse response) {
         AccessTokenResponse accessTokenResponse = tokenService.refreshAccessToken(request, response);
         return ResponseEntity.ok(accessTokenResponse);
+    }
+
+    @PostMapping("/refresh")
+    public Mono<ResponseEntity<AccessTokenResponse>> refreshAccessToken(ServerWebExchange exchange) {
+        return tokenService.refreshAccessTokenReactively(exchange) //TODO: Заменить вызов метода заглушки на готовый реактивный метод
+                .map(ResponseEntity::ok);
     }
 
     /**
      * Метод, принимающий GET запрос для редиректа на страницу входа Steam. Насыщается необходимыми для
      * OpenId query-параметрами и отправляет запрос в аутентификационный провайдер.
      */
-    @GetMapping("/steam")
-    public ResponseEntity<Void> redirectToSteamForAuthorization() {
+    @Deprecated(forRemoval = true)
+    @GetMapping("/steamOld")
+    public ResponseEntity<Void> redirectToSteamForAuthorizationOld() {
         MultiValueMap<String, String> queryParams = queryParamMultiValueMapGenerator();
 
         URI uri = UriComponentsBuilder
@@ -73,16 +101,40 @@ public class AuthController {
                 .build();
     }
 
+    @GetMapping("/steam")
+    public Mono<ResponseEntity<Void>> redirectToSteamForAuthorization() {
+        MultiValueMap<String, String> queryParams = queryParamMultiValueMapGenerator();
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(steamOpenIdLoginUrl)
+                .queryParams(queryParams)
+                .build(true)
+                .toUri();
+
+        return Mono.just(ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, uri.toString())
+                .build());
+    }
+
     /**
      * Ловим callback от провайдера аутентификации, верифицируем ответ от Steam.
      * Возвращает новые Refresh и Access токены в случае привязки пользователя по Steam Id
      */
-    @GetMapping("/steam/return")
-    public ResponseEntity<AccessTokenResponse> handleSteamCallback(OpenIdResponse openIdResponse,
+    @Deprecated(forRemoval = true)
+    @GetMapping("/steam/returnOld")
+    public ResponseEntity<AccessTokenResponse> handleSteamCallbackOld(OpenIdResponse openIdResponse,
                                                                    HttpServletRequest request,
                                                                    HttpServletResponse response) {
         AccessTokenResponse handledResponse = steamOpenIdResponseHandler.handle(openIdResponse, request, response);
         return ResponseEntity.ok(handledResponse);
+    }
+
+    @GetMapping("/steam/return")
+    public Mono<ResponseEntity<AccessTokenResponse>> handleSteamCallback(OpenIdResponse openIdResponse,
+                                                                         ServerWebExchange exchange) {
+        return steamOpenIdResponseHandler
+                .handleReactively(openIdResponse, exchange) //TODO: Заменить вызов метода заглушки на готовый реактивный метод
+                .map(ResponseEntity::ok);
     }
 
 

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/controller/GameRecommendationController.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/controller/GameRecommendationController.java
@@ -1,7 +1,7 @@
 package ru.perevalov.gamerecommenderai.controller;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
-import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.dto.GameRecommendationRequest;
 import ru.perevalov.gamerecommenderai.dto.GameRecommendationResponse;
 import ru.perevalov.gamerecommenderai.security.jwt.JwtUtil;
@@ -25,7 +26,8 @@ public class GameRecommendationController {
 
     private final GameRecommenderService gameRecommenderService;
 
-    @PostMapping("/proceed")
+    @Deprecated(forRemoval = true)
+    @PostMapping("/proceedOld")
     public ResponseEntity<GameRecommendationResponse> getUserGames(@RequestBody GameRecommendationRequest req) {
         log.info("Received game recommendation request: {}", req);
 
@@ -35,5 +37,15 @@ public class GameRecommendationController {
                 response.getRecommendations() != null ? response.getRecommendations().size() : 0);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/proceed")
+    public Mono<ResponseEntity<GameRecommendationResponse>> getRecommendations(
+            @RequestBody Mono<GameRecommendationRequest> reqMono
+    ) {
+        return gameRecommenderService.getRecommendationsReactively(reqMono)
+                .doOnNext(resp -> log.info("Returning response with {} recommendations",
+                        resp.getRecommendations() != null ? resp.getRecommendations().size() : 0))
+                .map(ResponseEntity::ok);
     }
 } 

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/TokenService.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/TokenService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.dto.AccessTokenResponse;
 import ru.perevalov.gamerecommenderai.dto.PreAuthResponse;
 import ru.perevalov.gamerecommenderai.entity.RefreshToken;
@@ -42,6 +44,8 @@ public class TokenService {
         return Duration.ofDays(refreshTtl);
     }
 
+    //TODO: Старый нереактивный метод, ранее вызываемый контроллером /preAuthorize. Удалить или отрефакторить
+    @Deprecated(forRemoval = true)
     public PreAuthResponse preAuthorize(HttpServletResponse response) {
         String sessionId = UUID.randomUUID().toString();
 
@@ -65,6 +69,18 @@ public class TokenService {
                 .build();
     }
 
+    //TODO: Заменить обращение контроллера с этого метода-заглушки к нормльаному реактивному методу
+    public Mono<PreAuthResponse> preAuthorizeReactively(ServerWebExchange exchange) {
+        return Mono.just(PreAuthResponse.builder()
+                .accessToken("Access-token-dummy-stub")
+                .accessExpiresIn(getAccessTtl().toSeconds())
+                .role(UserRole.GUEST.getAuthority())
+                .sessionId("Stub-session-id")
+                .steamId(null)
+                .build());
+    }
+
+    @Deprecated(forRemoval = true)
     public AccessTokenResponse refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
         String refreshTokenFromCookies = cookieService.extractRefreshTokenFromCookies(request.getCookies());
         RefreshToken storedRefreshToken = refreshTokenRepository.findByTokenOrThrow(refreshTokenFromCookies)
@@ -88,6 +104,13 @@ public class TokenService {
                 .accessToken(newAccessToken)
                 .accessExpiresIn(getAccessTtl().toSeconds())
                 .build();
+    }
+
+    public Mono<AccessTokenResponse> refreshAccessTokenReactively(ServerWebExchange exchange) {
+        return Mono.just(AccessTokenResponse.builder()
+                .accessToken("Access-token-dummy-stub")
+                .accessExpiresIn(getAccessTtl().toSeconds())
+                .build());
     }
 
     /**

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/steam/SteamOpenIdResponseHandler.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/steam/SteamOpenIdResponseHandler.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
 import ru.perevalov.gamerecommenderai.dto.AccessTokenResponse;
 import ru.perevalov.gamerecommenderai.dto.OpenIdResponse;
 import ru.perevalov.gamerecommenderai.entity.User;
@@ -39,6 +41,7 @@ public class SteamOpenIdResponseHandler {
      * @param request        - содержат Refresh токен, в которые вшивается Steam id
      * @return
      */
+    @Deprecated(forRemoval = true)
     public AccessTokenResponse handle(OpenIdResponse openIdResponse,
                                       HttpServletRequest request,
                                       HttpServletResponse response) {
@@ -64,5 +67,12 @@ public class SteamOpenIdResponseHandler {
             }
             return tokenService.linkSteamIdToToken(refreshTokenFromHeader, user.getSteamId(), response);
         }
+    }
+
+    public Mono<AccessTokenResponse> handleReactively(OpenIdResponse openIdResponse, ServerWebExchange exchange) {
+        return Mono.just(AccessTokenResponse.builder()
+                .accessToken("Access-token-dummy-stub")
+                .accessExpiresIn(900)
+                .build());
     }
 }

--- a/services/backend/src/main/resources/application.properties
+++ b/services/backend/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 spring.application.name=game-recommender-ai
 
+# Временная заглушка TODO: Убрать, когда секьюрити перейдет на реактивную модель (Когда удалим starter web из pom.xml)
+spring.main.web-application-type=reactive
+
 # Server configuration
 server.port=8080
 


### PR DESCRIPTION
+ Убрал зависимость на data jpa
+ Убрал exclude R2dbc классов из мейна, чтобы приложение могло запуститься
+ Выключил нереактивную security filter chain и добавил минимальную реактивную цепочку, разрешающую всё. Старые бины все еще конфигурируются и не мешают запуску приложения, но не работают при вызове
+ Нереактивные контроллеры были переименованы (к каждому добавлен суффикс Old: preAuthorize -> preAuthorizeOld и т.д.) и помечены как Deprecated для удаления в конце реактивной миграции
+ Были созданы новые реактивные контроллеры, которые были названы в соответствии с прежним названием нереактивных контроллеров, которых они замещают. Реактивные контроллеры обращаются к тем же сервисам, к которым обращались старые контроллеры, но к другим методам-заглушкам.
+ В сервисы GameRecommenderService, TokenService и SteamOpenIdResponseHandler были добавлены методы-заглушки, работающие как точки входа в сервисы для контроллеров. Схема нейминга - К названию метода, который заменяется заглушкой прибавляется суффикс Reactively (preAuthorize -> preAuthorizReactively).
+ Была добавлена зависимость для работы Open Api с webFlux. Старая конфигурация опен апи была закомменчена, новая будет сделана позже