### PR TITLE
PCAI-94: Исправление замечаний анализатора кода

### DIFF
--- a/services/backend/game-recommender-ai-backend.iml
+++ b/services/backend/game-recommender-ai-backend.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$" dumb="true">
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/protobuf/java" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/services/backend/game-recommender-ai-backend.iml
+++ b/services/backend/game-recommender-ai-backend.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$" dumb="true">
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/protobuf/java" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/ReactorMdcConfiguration.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/ReactorMdcConfiguration.java
@@ -1,0 +1,88 @@
+package ru.perevalov.gamerecommenderai.config;
+
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+@Configuration
+public class ReactorMdcConfiguration {
+
+    private static final String MDC_REACTOR_HOOK_KEY = "reactor-mdc";
+
+    @Value("${requestid.logging.param}")
+    private String requestIdLoggingParam;
+
+    @PostConstruct
+    public void setupHooks() {
+        Hooks.onEachOperator(MDC_REACTOR_HOOK_KEY, Operators.lift((scannable, subscriber) ->
+                new MdcContextLifter<>(subscriber, requestIdLoggingParam)));
+    }
+
+    @PreDestroy
+    public void cleanupHooks() {
+        Hooks.resetOnEachOperator(MDC_REACTOR_HOOK_KEY);
+    }
+
+    private static final class MdcContextLifter<T> implements CoreSubscriber<T> {
+
+        private final CoreSubscriber<? super T> delegate;
+        private final String requestIdMdcKey;
+
+        private MdcContextLifter(CoreSubscriber<? super T> delegate, String requestIdMdcKey) {
+            this.delegate = delegate;
+            this.requestIdMdcKey = requestIdMdcKey;
+        }
+
+        @Override
+        public Context currentContext() {
+            return delegate.currentContext();
+        }
+
+        @Override
+        public void onSubscribe(org.reactivestreams.Subscription subscription) {
+            withMdc(() -> delegate.onSubscribe(subscription));
+        }
+
+        @Override
+        public void onNext(T value) {
+            withMdc(() -> delegate.onNext(value));
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            withMdc(() -> delegate.onError(throwable));
+        }
+
+        @Override
+        public void onComplete() {
+            withMdc(delegate::onComplete);
+        }
+
+        private void withMdc(Runnable runnable) {
+            Context context = delegate.currentContext();
+            String previous = MDC.get(requestIdMdcKey);
+
+            try {
+                if (context.hasKey(requestIdMdcKey)) {
+                    MDC.put(requestIdMdcKey, context.get(requestIdMdcKey));
+                } else {
+                    MDC.remove(requestIdMdcKey);
+                }
+                runnable.run();
+            } finally {
+                if (previous == null) {
+                    MDC.remove(requestIdMdcKey);
+                } else {
+                    MDC.put(requestIdMdcKey, previous);
+                }
+            }
+        }
+    }
+}

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/filter/RateLimitWebFilter.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/filter/RateLimitWebFilter.java
@@ -66,7 +66,12 @@ public class RateLimitWebFilter implements WebFilter {
                     return bucket.tryConsumeAndReturnRemaining(1);
                 })
                 .subscribeOn(Schedulers.boundedElastic())
-                .flatMap(probe -> handleProbe(exchange, chain, probe));
+                .flatMap(probe -> handleProbe(exchange, chain, probe))
+                .onErrorResume(ex -> {
+                    log.warn("Rate limiter failed (Redis issue). Allowing request (fail-open). key={}, path={}",
+                            key, exchange.getRequest().getPath().value(), ex);
+                    return chain.filter(exchange);
+                });
     }
 
     private Mono<Void> handleProbe(ServerWebExchange exchange, WebFilterChain chain, ConsumptionProbe probe) {

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/filter/RequestIdWebFilter.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/filter/RequestIdWebFilter.java
@@ -2,7 +2,6 @@ package ru.perevalov.gamerecommenderai.filter;
 
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -12,7 +11,7 @@ import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
 /**
- * WebFilter for generating request id and attaching it to headers and MDC.
+ * WebFilter for generating request id and attaching it to headers and Reactor context.
  */
 @Slf4j
 @Component
@@ -25,6 +24,8 @@ public class RequestIdWebFilter implements WebFilter {
     @Value("${requestid.logging.param}")
     private String requestIdLoggingParam;
 
+    public static final String REQUEST_ID_CONTEXT_KEY = "requestId";
+
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         String requestId = exchange.getRequest().getHeaders().getFirst(requestIdHeaderKey);
@@ -32,10 +33,12 @@ public class RequestIdWebFilter implements WebFilter {
             requestId = UUID.randomUUID().toString();
         }
 
-        MDC.put(requestIdLoggingParam, requestId);
-        exchange.getResponse().getHeaders().set(requestIdHeaderKey, requestId);
+        final String finalRequestId = requestId;
+
+        exchange.getResponse().getHeaders().set(requestIdHeaderKey, finalRequestId);
 
         return chain.filter(exchange)
-                .doFinally(signalType -> MDC.remove(requestIdLoggingParam));
+                .contextWrite(context -> context.put(REQUEST_ID_CONTEXT_KEY, finalRequestId)
+                .put(requestIdLoggingParam, finalRequestId));
     }
 }

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/interceptor/GrpcRequestIdClientInterceptor.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/interceptor/GrpcRequestIdClientInterceptor.java
@@ -20,11 +20,15 @@ public class GrpcRequestIdClientInterceptor implements ClientInterceptor {
     @Value("${requestid.header.key}")
     private String requestIdHeaderKey;
 
+    @Value("${requestid.logging.param}")
+    private String requestIdLoggingParam;
+
+
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
                                                                CallOptions callOptions, Channel next) {
         Metadata headers = new Metadata();
-        String rqUid = MDC.get(requestIdHeaderKey);
+        String rqUid = MDC.get(requestIdLoggingParam);
 
         if (rqUid != null && !rqUid.isEmpty()) {
             Metadata.Key<String> rqUidHeader = Metadata.Key.of(requestIdHeaderKey, Metadata.ASCII_STRING_MARSHALLER);

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/jwt/JwtUtil.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/jwt/JwtUtil.java
@@ -18,7 +18,7 @@ import java.util.Date;
 @Component
 public class JwtUtil {
     @Value("${security.jwt.secret}")
-    private String jwtLegacySecret;
+    private String jwtAccessSecret;
 
     @Value("${security.jwt.refresh-secret}")
     private String jwtRefreshSecret;
@@ -27,7 +27,7 @@ public class JwtUtil {
     private String issuer;
 
     public String createAccessToken(String sessionId, Duration ttl, UserRole role, Long steamId) {
-        return createToken(sessionId, ttl, role, steamId, TokenType.ACCESS, jwtLegacySecret);
+        return createToken(sessionId, ttl, role, steamId, TokenType.ACCESS, jwtAccessSecret);
     }
 
     public String createRefreshToken(String sessionId, Duration ttl, UserRole role, Long steamId) {
@@ -61,15 +61,11 @@ public class JwtUtil {
     }
 
     public DecodedJWT decodeAccessToken(String token) {
-        return decodeToken(token, jwtLegacySecret);
+        return decodeToken(token, jwtAccessSecret);
     }
 
     public DecodedJWT decodeRefreshToken(String token) {
-        try {
             return decodeToken(token, jwtRefreshSecret);
-        } catch (JWTVerificationException ex) {
-            return decodeToken(token, jwtLegacySecret);
-        }
     }
 
     private DecodedJWT decodeToken(String token, String secret) {

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/jwt/JwtUtil.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/jwt/JwtUtil.java
@@ -65,7 +65,7 @@ public class JwtUtil {
     }
 
     public DecodedJWT decodeRefreshToken(String token) {
-            return decodeToken(token, jwtRefreshSecret);
+        return decodeToken(token, jwtRefreshSecret);
     }
 
     private DecodedJWT decodeToken(String token, String secret) {

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/jwt/JwtUtil.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/jwt/JwtUtil.java
@@ -3,6 +3,7 @@ package ru.perevalov.gamerecommenderai.security.jwt;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -17,7 +18,7 @@ import java.util.Date;
 @Component
 public class JwtUtil {
     @Value("${security.jwt.secret}")
-    private String jwtAccessSecret;
+    private String jwtLegacySecret;
 
     @Value("${security.jwt.refresh-secret}")
     private String jwtRefreshSecret;
@@ -26,7 +27,7 @@ public class JwtUtil {
     private String issuer;
 
     public String createAccessToken(String sessionId, Duration ttl, UserRole role, Long steamId) {
-        return createToken(sessionId, ttl, role, steamId, TokenType.ACCESS, jwtAccessSecret);
+        return createToken(sessionId, ttl, role, steamId, TokenType.ACCESS, jwtLegacySecret);
     }
 
     public String createRefreshToken(String sessionId, Duration ttl, UserRole role, Long steamId) {
@@ -60,11 +61,15 @@ public class JwtUtil {
     }
 
     public DecodedJWT decodeAccessToken(String token) {
-        return decodeToken(token, jwtAccessSecret);
+        return decodeToken(token, jwtLegacySecret);
     }
 
     public DecodedJWT decodeRefreshToken(String token) {
-        return decodeToken(token, jwtRefreshSecret);
+        try {
+            return decodeToken(token, jwtRefreshSecret);
+        } catch (JWTVerificationException ex) {
+            return decodeToken(token, jwtLegacySecret);
+        }
     }
 
     private DecodedJWT decodeToken(String token, String secret) {


### PR DESCRIPTION
При недоступности Redis rate limiter валил все запросы с 500, что могло привести к полному outage API - API остаётся доступным даже при проблемах с Redis

После разделения секретов все старые refresh-токены стали невалидны - нет массового разлогина, все пользователи автоматически мигрируют на новый секрет

MDC (некорректно работает в WebFlux, requestId терялся между запросами - корректная корреляция запросов в WebFlux и gRPC без зависимости от ThreadLocal