### PR TITLE
PCAI-96: Валидация библиотеки и сохранение как jsonb, вынос syncUserData в другой поток

### DIFF
--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/R2dbcConfig.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/config/R2dbcConfig.java
@@ -12,6 +12,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
 import ru.perevalov.gamerecommenderai.entity.converter.JsonNodeReadingConverter;
 import ru.perevalov.gamerecommenderai.entity.converter.JsonNodeWritingConverter;
+import ru.perevalov.gamerecommenderai.entity.converter.OwnedGamesSnapshotReadConverter;
+import ru.perevalov.gamerecommenderai.entity.converter.OwnedGamesSnapshotWriteConverter;
 import ru.perevalov.gamerecommenderai.entity.converter.UserRoleEnumTypeConverter;
 import ru.perevalov.gamerecommenderai.security.model.UserRole;
 
@@ -33,6 +35,8 @@ public class R2dbcConfig extends AbstractR2dbcConfiguration {
     private final UserRoleEnumTypeConverter userRoleEnumTypeConverter;
     private final JsonNodeWritingConverter jsonNodeWritingConverter;
     private final JsonNodeReadingConverter jsonNodeReadingConverter;
+    private final OwnedGamesSnapshotWriteConverter ownedGamesSnapshotWriteConverter;
+    private final OwnedGamesSnapshotReadConverter ownedGamesSnapshotReadConverter;
 
     @Override
     public ConnectionFactory connectionFactory() {
@@ -44,7 +48,9 @@ public class R2dbcConfig extends AbstractR2dbcConfiguration {
         return List.of(
                 userRoleEnumTypeConverter,
                 jsonNodeWritingConverter,
-                jsonNodeReadingConverter
+                jsonNodeReadingConverter,
+                ownedGamesSnapshotWriteConverter,
+                ownedGamesSnapshotReadConverter
         );
     }
 

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/UserGameStats.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/UserGameStats.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
+import ru.perevalov.gamerecommenderai.entity.embedded.OwnedGamesSnapshot;
 
 import java.util.UUID;
 
@@ -59,5 +60,8 @@ public class UserGameStats extends BaseEntity {
 
     @Column("user_id")
     private UUID userId;
+
+    @Column("owned_games_snapshot")
+    private OwnedGamesSnapshot ownedGamesSnapshot;
 
 }

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/converter/OwnedGamesSnapshotReadConverter.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/converter/OwnedGamesSnapshotReadConverter.java
@@ -1,0 +1,31 @@
+package ru.perevalov.gamerecommenderai.entity.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.r2dbc.postgresql.codec.Json;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.stereotype.Component;
+import ru.perevalov.gamerecommenderai.entity.embedded.OwnedGamesSnapshot;
+
+import java.io.IOException;
+
+@Slf4j
+@ReadingConverter
+@Component
+@RequiredArgsConstructor
+public class OwnedGamesSnapshotReadConverter implements Converter<Json, OwnedGamesSnapshot> {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public OwnedGamesSnapshot convert(Json source) {
+        try {
+            return objectMapper.readValue(source.asString(), OwnedGamesSnapshot.class);
+        } catch (IOException e) {
+            log.error("Failed to deserialize OwnedGamesSnapshot from JSON", e);
+            return null;
+        }
+    }
+}

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/converter/OwnedGamesSnapshotWriteConverter.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/converter/OwnedGamesSnapshotWriteConverter.java
@@ -1,0 +1,30 @@
+package ru.perevalov.gamerecommenderai.entity.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.r2dbc.postgresql.codec.Json;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.stereotype.Component;
+import ru.perevalov.gamerecommenderai.entity.embedded.OwnedGamesSnapshot;
+
+@Slf4j
+@WritingConverter
+@Component
+@RequiredArgsConstructor
+public class OwnedGamesSnapshotWriteConverter implements Converter<OwnedGamesSnapshot, Json> {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Json convert(OwnedGamesSnapshot source) {
+        try {
+            return Json.of(objectMapper.writeValueAsString(source));
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize OwnedGamesSnapshot to JSON", e);
+            return null;
+        }
+    }
+}

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/embedded/OwnedGamesSnapshot.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/entity/embedded/OwnedGamesSnapshot.java
@@ -1,0 +1,37 @@
+package ru.perevalov.gamerecommenderai.entity.embedded;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OwnedGamesSnapshot {
+
+    private Response response;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+
+        private Integer gameCount;
+
+        private List<Game> games;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Game {
+
+        private Long appId;
+
+        private String name;
+
+        private Integer playtime2weeks;
+
+        private Integer playtimeForever;
+
+        private Integer rtimeLastPlayed;
+    }
+}

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/exception/ErrorType.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/exception/ErrorType.java
@@ -53,7 +53,8 @@ public enum ErrorType {
     STEAM_STORE_API_FETCH_APP_DETAILS_ERROR("Failed to fetch app details from Steam Store API with appIds=%s", HttpStatus.SERVICE_UNAVAILABLE),
     USER_GAME_STATS_SAVE_ERROR("Failed to save user game stats. steamId=%s", HttpStatus.INTERNAL_SERVER_ERROR),
     USER_STEAM_PROFILE_SAVE_ERROR("Failed to save Steam profile. steamId=%s", HttpStatus.INTERNAL_SERVER_ERROR),
-    USER_NOT_FOUND("User with steam id %s was not found in system.", HttpStatus.NOT_FOUND);
+    USER_NOT_FOUND("User with steam id %s was not found in system.", HttpStatus.NOT_FOUND),
+    USER_GAME_STATS_VALIDATION_ERROR("User game stats validation failed: %s for steamId=%s", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String description;
     private final HttpStatus status;

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/mapper/OwnedGamesSnapshotMapper.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/mapper/OwnedGamesSnapshotMapper.java
@@ -1,0 +1,14 @@
+package ru.perevalov.gamerecommenderai.mapper;
+
+import org.mapstruct.Mapper;
+import ru.perevalov.gamerecommenderai.dto.steam.SteamOwnedGamesResponse;
+import ru.perevalov.gamerecommenderai.entity.embedded.OwnedGamesSnapshot;
+
+@Mapper(componentModel = "spring")
+public interface OwnedGamesSnapshotMapper {
+
+    /**
+     * Converts a {@link SteamOwnedGamesResponse} to an {@link OwnedGamesSnapshot}.
+     */
+    OwnedGamesSnapshot toSnapshot(SteamOwnedGamesResponse source);
+}

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/steam/SteamOpenIdResponseHandler.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/security/steam/SteamOpenIdResponseHandler.java
@@ -1,13 +1,14 @@
 package ru.perevalov.gamerecommenderai.security.steam;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import ru.perevalov.gamerecommenderai.dto.AccessTokenResponse;
 import ru.perevalov.gamerecommenderai.dto.OpenIdResponse;
 import ru.perevalov.gamerecommenderai.exception.ErrorType;
@@ -48,8 +49,13 @@ public class SteamOpenIdResponseHandler {
                     }
 
                     return tokenService.linkSteamIdToToken(refreshToken, steamId, exchange)
-                            .flatMap(tokens ->
-                                    steamUserDataService.syncUserData(user).thenReturn(tokens)
+                            .doOnNext(tokens ->
+                                    Mono.defer(() -> steamUserDataService.syncUserData(user))
+                                            .subscribeOn(Schedulers.boundedElastic())
+                                            .subscribe(
+                                                    unused -> {},
+                                                    err -> log.error("User data sync failed for user={}", user.getId(), err)
+                                            )
                             );
                 })
                 .doOnSuccess(resp -> meterRegistry.counter("steam_auth_success").increment())

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/SteamUserDataService.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/SteamUserDataService.java
@@ -11,6 +11,7 @@ import ru.perevalov.gamerecommenderai.entity.User;
 import ru.perevalov.gamerecommenderai.entity.UserGameStats;
 import ru.perevalov.gamerecommenderai.exception.ErrorType;
 import ru.perevalov.gamerecommenderai.exception.GameRecommenderException;
+import ru.perevalov.gamerecommenderai.mapper.OwnedGamesSnapshotMapper;
 import ru.perevalov.gamerecommenderai.repository.SteamProfileRepository;
 import ru.perevalov.gamerecommenderai.repository.UserGameStatsRepository;
 
@@ -29,6 +30,8 @@ public class SteamUserDataService {
     private final SteamProfileRepository steamProfileRepository;
     private final UserGameStatsRepository userGameStatsRepository;
     private final UserDataCacheService userDataCacheService;
+    private final OwnedGamesSnapshotMapper ownedGamesSnapshotMapper;
+    private final UserGameStatsValidator userGameStatsValidator;
 
     /**
      * Fetches user profile and game stats from Steam API and stores them in DB + Redis cache.
@@ -84,6 +87,7 @@ public class SteamUserDataService {
     private Mono<Void> syncUserGameStats(Long steamId, UUID userId) {
         return steamService.getOwnedGames(String.valueOf(steamId), true, true)
                 .map(resp -> buildStats(steamId, userId, resp))
+                .doOnNext(userGameStatsValidator::validate)
                 .flatMap(stats -> upsertUserGameStats(userId, stats))
                 .flatMap(saved -> userDataCacheService.saveUserGameStats(steamId, saved).thenReturn(saved))
                 .doOnSuccess(saved -> log.info("User game stats synced for steamId={}, userId={}", steamId, userId))
@@ -133,6 +137,8 @@ public class SteamUserDataService {
                     existing.setFavoriteGenreCount(newStats.getFavoriteGenreCount());
                     existing.setFavoriteGenreHours(newStats.getFavoriteGenreHours());
 
+                    existing.setOwnedGamesSnapshot(newStats.getOwnedGamesSnapshot());
+
                     return userGameStatsRepository.save(existing);
                 })
                 .switchIfEmpty(Mono.defer(() -> userGameStatsRepository.save(newStats)))
@@ -177,6 +183,8 @@ public class SteamUserDataService {
             stats.setLastPlayedGameName(lastPlayed.getName());
             stats.setLastPlaytime(lastPlayed.getRtimeLastPlayed());
         }
+
+        stats.setOwnedGamesSnapshot(ownedGamesSnapshotMapper.toSnapshot(ownedGamesResponse));
 
         return stats;
     }

--- a/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/UserGameStatsValidator.java
+++ b/services/backend/src/main/java/ru/perevalov/gamerecommenderai/service/UserGameStatsValidator.java
@@ -1,0 +1,60 @@
+package ru.perevalov.gamerecommenderai.service;
+
+import org.springframework.stereotype.Component;
+import ru.perevalov.gamerecommenderai.entity.UserGameStats;
+import ru.perevalov.gamerecommenderai.exception.ErrorType;
+import ru.perevalov.gamerecommenderai.exception.GameRecommenderException;
+
+@Component
+public class UserGameStatsValidator {
+
+    private static final String TOTAL_GAMES_OWNED = "totalGamesOwned";
+    private static final String TOTAL_PLAYTIME_FOREVER = "totalPlaytimeForever";
+    private static final String TOTAL_PLAYTIME_LAST_TWO_WEEKS = "totalPlaytimeLastTwoWeeks";
+    private static final String MOST_PLAYED_GAME_HOURS = "mostPlayedGameHours";
+    private static final String MOST_PLAYED_GAME_ID = "mostPlayedGameId";
+    private static final String MOST_PLAYED_GAME_NAME = "mostPlayedGameName";
+    private static final String LAST_PLAYTIME = "lastPlaytime";
+    private static final String LAST_PLAYED_GAME_ID = "lastPlayedGameId";
+    private static final String LAST_PLAYED_GAME_NAME = "lastPlayedGameName";
+
+    public void validate(UserGameStats stats) {
+        Long id = stats.getSteamId();
+        validateFieldIsNonNegative(stats.getTotalGamesOwned(), TOTAL_GAMES_OWNED, id);
+        validateFieldIsNonNegative(stats.getTotalPlaytimeForever(), TOTAL_PLAYTIME_FOREVER, id);
+        validateFieldIsNonNegative(stats.getTotalPlaytimeLastTwoWeeks(), TOTAL_PLAYTIME_LAST_TWO_WEEKS, id);
+        validateFieldIsNonNegative(stats.getMostPlayedGameHours(), MOST_PLAYED_GAME_HOURS, id);
+        validateFieldIsNonNegative(stats.getLastPlaytime(), LAST_PLAYTIME, id);
+
+        validateConsistency(
+                stats.getMostPlayedGameId(), stats.getMostPlayedGameName(),
+                MOST_PLAYED_GAME_ID, MOST_PLAYED_GAME_NAME, id);
+        validateConsistency(
+                stats.getMostPlayedGameId(), stats.getMostPlayedGameHours(),
+                MOST_PLAYED_GAME_ID, MOST_PLAYED_GAME_HOURS, id);
+        validateConsistency(
+                stats.getLastPlayedGameId(), stats.getLastPlayedGameName(),
+                LAST_PLAYED_GAME_ID, LAST_PLAYED_GAME_NAME, id);
+    }
+
+    private void validateFieldIsNonNegative(Number fieldValue, String fieldName, Long steamId) {
+        if (fieldValue != null && fieldValue.longValue() < 0) {
+            throw new GameRecommenderException(
+                    ErrorType.USER_GAME_STATS_VALIDATION_ERROR,
+                    fieldName + " is negative",
+                    steamId
+            );
+        }
+    }
+
+    private void validateConsistency(Object requiringField, Object requiredField,
+                                     String requiringName, String requiredName, Long steamId) {
+        if (requiringField != null && requiredField == null) {
+            throw new GameRecommenderException(
+                    ErrorType.USER_GAME_STATS_VALIDATION_ERROR,
+                    requiredName + " is null when " + requiringName + " is set",
+                    steamId
+            );
+        }
+    }
+}

--- a/services/backend/src/main/resources/db/changelog/sql/v1/010_AddOwnedGamesSnapshotToUserGameStats.sql
+++ b/services/backend/src/main/resources/db/changelog/sql/v1/010_AddOwnedGamesSnapshotToUserGameStats.sql
@@ -1,0 +1,2 @@
+ALTER TABLE game_recommender.user_game_stats
+    ADD COLUMN owned_games_snapshot JSONB;

--- a/services/backend/src/main/resources/db/changelog/v1/changelog-1.0.xml
+++ b/services/backend/src/main/resources/db/changelog/v1/changelog-1.0.xml
@@ -45,4 +45,8 @@
         <sqlFile path="../sql/v1/009_AddUpdatedAtToChatMessages.sql" relativeToChangelogFile="true"/>
     </changeSet>
 
+    <changeSet id="10-add-owned-games-snapshot-to-user-game-stats" author="Ekaterina Katyshevtseva">
+        <sqlFile path="../sql/v1/010_AddOwnedGamesSnapshotToUserGameStats.sql" relativeToChangelogFile="true"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
В UserGameStats добавлено поле для хранения всего ответа от Steam.
Синхронизация данных, которая выполняется при авторизации, вынесена в отдельный поток.
Значения UserGameStats проходят валидацию перед сохранением.